### PR TITLE
Fix Google Maps script reloading

### DIFF
--- a/frontend/app/(without-map)/admin/step/create/page.tsx
+++ b/frontend/app/(without-map)/admin/step/create/page.tsx
@@ -3,7 +3,6 @@ import { useEffect, useState } from "react";
 import NotificationToast from "@/components/NotificationToast";
 import { API_BASE_URL } from "@/lib/config";
 import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
 
 interface Trip {
   id: number;

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -4,7 +4,8 @@ import { Geist, Geist_Mono } from "next/font/google";
 import Header from "../components/Header";
 import SessionWrapper from "./sessionWrapper";
 import "../styles/globals.css";
-import {GoogleOAuthProvider} from "@react-oauth/google";
+import { GoogleOAuthProvider } from "@react-oauth/google";
+import MapProvider from "../components/MapProvider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -30,10 +31,12 @@ export default function RootLayout({
       <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased flex flex-col min-h-screen`}>
       <GoogleOAuthProvider clientId={process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID!}>
-        <SessionWrapper>
-          <Header />
-          {children}
-        </SessionWrapper>
+        <MapProvider>
+          <SessionWrapper>
+            <Header />
+            {children}
+          </SessionWrapper>
+        </MapProvider>
       </GoogleOAuthProvider>
       </body>
       </html>

--- a/frontend/app/mapLayout.tsx
+++ b/frontend/app/mapLayout.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import GoogleMapsProvider from '../components/MapProvider';
-
 export default function mapLayout({ children }: { children: React.ReactNode }) {
-  return <GoogleMapsProvider>{children}</GoogleMapsProvider>;
+  return <>{children}</>;
 }

--- a/frontend/components/Map.tsx
+++ b/frontend/components/Map.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { GoogleMap, LoadScript, Polyline } from '@react-google-maps/api';
+import { GoogleMap, Polyline } from '@react-google-maps/api';
 import { useRef, useEffect, useState, useMemo } from 'react';
 
 const containerStyle = {
@@ -170,21 +170,19 @@ export default function Map() {
     }, []);
 
     return (
-        <LoadScript googleMapsApiKey={process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY!}>
-            <GoogleMap
-                mapContainerStyle={containerStyle}
-                onLoad={onLoad}
-                options={mapOptions}
-            >
-                <Polyline
-                    path={pathCoordinates}
-                    options={{
-                        strokeColor: '#FF0000',
-                        strokeOpacity: 0.8,
-                        strokeWeight: 2,
-                    }}
-                />
-            </GoogleMap>
-        </LoadScript>
+        <GoogleMap
+            mapContainerStyle={containerStyle}
+            onLoad={onLoad}
+            options={mapOptions}
+        >
+            <Polyline
+                path={pathCoordinates}
+                options={{
+                    strokeColor: '#FF0000',
+                    strokeOpacity: 0.8,
+                    strokeWeight: 2,
+                }}
+            />
+        </GoogleMap>
     );
 }


### PR DESCRIPTION
## Summary
- load Google Maps script once via `MapProvider` in root layout
- simplify `mapLayout`
- remove unused label import in step create page
- update `Map` component to drop internal `LoadScript`

## Testing
- `npm run lint`
- `./mvnw -q test` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687cd9855e548327a40db9a5f8d4c3de